### PR TITLE
Sprint 1 — split secret scan: PR-blocking + history-informational

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,24 +1,47 @@
-name: gitleaks
+name: Secret scan (history)
 
 on:
-  pull_request:
   push:
     branches: [main]
   schedule:
     - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: read
+  issues: write
 
 jobs:
   scan:
-    name: Secret scan
+    name: Secret scan history
     runs-on: ubuntu-latest
+    # Informational only: history scan finds known historical leak (Issue #9 / NVIDIA key)
+    # which must be remediated via filter-repo + force-push, not by failing CI.
+    # When #9 is closed, flip this to required.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          GL_VERSION="8.21.2"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GL_VERSION}/gitleaks_${GL_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+      - name: Scan full history
+        run: |
+          gitleaks detect \
+            --source . \
+            --redact \
+            --no-banner \
+            --report-format sarif \
+            --report-path gitleaks-history.sarif \
+            --exit-code 0 || true
+      - name: Upload SARIF
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-history-sarif
+          path: gitleaks-history.sarif
+          if-no-files-found: ignore

--- a/.github/workflows/secret-scan-pr.yml
+++ b/.github/workflows/secret-scan-pr.yml
@@ -1,0 +1,47 @@
+name: Secret scan (PR)
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          GL_VERSION="8.21.2"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GL_VERSION}/gitleaks_${GL_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Scan PR diff only
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          echo "Scanning commits ${BASE_SHA}..${HEAD_SHA}"
+          gitleaks detect \
+            --source . \
+            --redact \
+            --no-banner \
+            --log-opts="${BASE_SHA}..${HEAD_SHA}" \
+            --report-format sarif \
+            --report-path gitleaks-pr.sarif \
+            --exit-code 1
+      - name: Upload SARIF
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-pr-sarif
+          path: gitleaks-pr.sarif
+          if-no-files-found: ignore


### PR DESCRIPTION
## Sprint 1 — Split secret scanning into PR-blocking + history-informational

### Problem
The previous `gitleaks` workflow scanned **full history** on every PR. Because the repo contains a known historical leak (NVIDIA API key, tracked in Issue #9), every PR was blocked even when the diff itself was clean. This made the new branch-protection unusable.

### Fix
- **`secret-scan-pr.yml`** — runs on PR, scans only `base..head` diff. **Required, blocking.** Same check name (`Secret scan`) keeps branch protection working.
- **`gitleaks.yml`** — renamed to history scan, runs on push to `main` + weekly schedule. **`continue-on-error: true`**, informational SARIF artifact only. When Issue #9 is fully remediated (key rotated, history rewritten with `git filter-repo`), this can be flipped back to required.

### Verification
After this PR merges, the same `Secret scan` check on subsequent PRs will scan only the diff, so a clean PR passes immediately.

### References
- Issue #9 (PS) — NVIDIA API key remediation tracker
- PLAN.md Sprint 1
- COMPETITIVE_STRATEGY.md (no copying of secrets ever)

Closes the secret-scan blocker for Sprint 1.
